### PR TITLE
using the new addon to deploy agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-HUB_KUBECONFIG ?= $(HOME)/hub-kubeconfig
 MANAGED_CLUSTER_NAME ?= cluster1
 TEST_TMP :=/tmp
 export KUBEBUILDER_ASSETS ?=$(TEST_TMP)/kubebuilder/bin
@@ -115,15 +114,10 @@ deploy-hub:
 	kubectl apply -f deploy/hub-common
 	kubectl apply -f deploy/hub
 
-.PHONY: deploy-managed
+.PHONY: deploy-addon
 
-deploy-managed:
-	cp -f $(HUB_KUBECONFIG) /tmp/kubeconfig
-	kubectl get ns open-cluster-management-agent-addon ; if [ $$? -ne 0 ] ; then kubectl create ns open-cluster-management-agent-addon ; fi
-	kubectl -n open-cluster-management-agent-addon delete secret appmgr-hub-kubeconfig --ignore-not-found
-	kubectl -n open-cluster-management-agent-addon create secret generic appmgr-hub-kubeconfig --from-file=kubeconfig=/tmp/kubeconfig
-	kubectl apply -f deploy/managed-common
-	$(SED_CMD) -e "s,managed_cluster_name,$(MANAGED_CLUSTER_NAME)," deploy/managed/operator.yaml | kubectl apply -f -
+deploy-addon:
+	$(SED_CMD) -e "s,managed_cluster_name,$(MANAGED_CLUSTER_NAME)," deploy/addon/addon.yaml | kubectl apply -f -
 
 
 build-e2e:

--- a/README.md
+++ b/README.md
@@ -54,17 +54,29 @@ Setup a _hub_ cluster and a _managed_ cluster using [clusteradm](https://github.
 Deploy the subscription operator on the _hub_ cluster.
 
 ```shell
+$ kubectl config use-context _hub_cluster_context_ # replace _hub_cluster_context_ with the hub cluster context name
 $ make deploy-hub
 $ kubectl -n open-cluster-management get deploy  multicloud-operators-subscription
 NAME                                READY   UP-TO-DATE   AVAILABLE   AGE
 multicloud-operators-subscription   1/1     1            1           25s
 ```
 
-Deploy the subscription agent on the _managed_ cluster.
+Deploy the subscription add-on on the _hub_ cluster's _managed_ cluster namespace. For example, `cluster1`.
 
 ```shell
-$ make deploy-managed 
-$ kubectl -n open-cluster-management-agent-addon get deploy  multicloud-operators-subscription
+$ kubectl config use-context _hub_cluster_context_ # replace _hub_cluster_context_ with the hub cluster context name
+$ export MANAGED_CLUSTER_NAME=_managed_cluster_name_ # replace _managed_cluster_name_ with the managed cluster name, ie export MANAGED_CLUSTER_NAME=cluster1
+$ make deploy-addon
+$ kubectl -n cluster1 get managedclusteraddon
+NAME                  AVAILABLE   DEGRADED   PROGRESSING
+application-manager   True                   
+```
+
+Check the the subscription add-on deployment on the _managed_ cluster.
+
+```shell
+$ kubectl config use-context _managed_cluster_context_ # replace _managed_cluster_context_ with the managed cluster context name
+$ kubectl -n open-cluster-management-agent get deploy multicloud-operators-subscription
 NAME                                READY   UP-TO-DATE   AVAILABLE   AGE
 multicloud-operators-subscription   1/1     1            1           103s
 ```

--- a/deploy/addon/addon.yaml
+++ b/deploy/addon/addon.yaml
@@ -1,0 +1,7 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: application-manager
+  namespace: managed_cluster_name
+spec:
+  installNamespace: open-cluster-management-agent

--- a/deploy/managed/operator.yaml
+++ b/deploy/managed/operator.yaml
@@ -1,5 +1,3 @@
-# before applying, filled in the <managed cluster name> and <managed cluster namespace> and run the following command:
-# kubectl -n multicloud-operators create secret generic appmgr-hub-kubeconfig --from-file=kubeconfig=</path/to/hub_cluster/kubeconfig> # note: the file name must be 'kubeconfig'
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

Ideally the addon should be deployed to the `open-cluster-management-agent-addon`
But since that namespace needs to be created manually. I think it's easy for the user and code to just use the `open-cluster-management-agent` namespace for now.